### PR TITLE
Bound multi-frame receive to the caller's actual buffer

### DIFF
--- a/example/send_receive/send_receive.ino
+++ b/example/send_receive/send_receive.ino
@@ -28,6 +28,8 @@ void setup()
   // buffers
   txMsg.Buffer = (uint8_t *)calloc(MAX_MSGBUF, sizeof(uint8_t));
   rxMsg.Buffer = (uint8_t *)calloc(MAX_MSGBUF, sizeof(uint8_t));
+  txMsg.buffer_size = MAX_MSGBUF;
+  rxMsg.buffer_size = MAX_MSGBUF;
 }
 
 void loop()

--- a/iso-tp.cpp
+++ b/iso-tp.cpp
@@ -8,7 +8,12 @@ IsoTp::IsoTp(MCP_CAN* bus, uint8_t mcp_int)
 {
   _mcp_int = mcp_int;
   _bus = bus;
-  _max_message_size = MAX_MSGBUF;
+}
+
+/* Bytes the caller's Buffer can hold; 0 means the MAX_MSGBUF fallback. */
+uint16_t IsoTp::buffer_capacity(struct Message_t* msg)
+{
+  return msg->buffer_size ? msg->buffer_size : MAX_MSGBUF;
 }
 
 void IsoTp::print_buffer(INT32U id, uint8_t *buffer, uint16_t len)
@@ -125,8 +130,14 @@ void IsoTp::fc_delay(uint8_t sep_time)
 
 uint8_t IsoTp::rcv_sf(struct Message_t* msg)
 {
+  uint16_t cap = buffer_capacity(msg);
+
   /* get the SF_DL from the N_PCI byte */
   msg->len = rxBuffer[0] & 0x0F;
+  /* SF holds <= 7 bytes; clamp to frame and buffer to bound read and write */
+  if (msg->len > 7) msg->len = 7;
+  if (rxLen > 0 && msg->len > (uint16_t)(rxLen - 1)) msg->len = rxLen - 1;
+  if (msg->len > cap) msg->len = cap;
   /* copy the received data bytes */
   memcpy(msg->Buffer,rxBuffer+1,msg->len); // Skip PCI, SF uses len bytes
   msg->tp_state=ISOTP_FINISHED;
@@ -136,18 +147,33 @@ uint8_t IsoTp::rcv_sf(struct Message_t* msg)
 
 uint8_t IsoTp::rcv_ff(struct Message_t* msg)
 {
+  uint16_t cap = buffer_capacity(msg);
+
   msg->seq_id=1;
 
-  /* get the FF_DL */
+  /* get the FF_DL (12 bits wide, so intrinsically <= 4095) */
   msg->len = (rxBuffer[0] & 0x0F) << 8;
   msg->len += rxBuffer[1];
 
-  if (msg->len > _max_message_size) {
-      msg->len = _max_message_size;
+  /* FF is only valid for FF_DL > 7; reject malformed short FF (rest underflow) */
+  if (msg->len < 8)
+  {
+    msg->tp_state = ISOTP_ERROR;
+    return 1;
   }
 
-  /* copy the first received data bytes */
-  memcpy(msg->Buffer,rxBuffer+2,6); // Skip 2 bytes PCI, FF must have 6 bytes!
+  if (msg->len > cap) msg->len = cap;
+
+  /* copy the first 6 data bytes, bounded by the buffer */
+  uint16_t first = (cap < 6) ? cap : 6;
+  memcpy(msg->Buffer,rxBuffer+2,first); // Skip 2 bytes PCI
+
+  if (msg->len <= 6) // no room for any CF
+  {
+    msg->tp_state = ISOTP_FINISHED;
+    return 0;
+  }
+
   rest=msg->len - 6; // Restlength
 
   msg->tp_state = ISOTP_WAIT_DATA;
@@ -205,8 +231,9 @@ uint8_t IsoTp::rcv_cf(struct Message_t* msg)
     return 1;
   }
 
-  uint16_t offset = 6 + 7 * (msg->seq_id - 1);
-  uint16_t remaining_buf = (offset < _max_message_size) ? (_max_message_size - offset) : 0;
+  uint16_t cap = buffer_capacity(msg);
+  uint32_t offset = 6u + 7u * (uint32_t)(msg->seq_id - 1);
+  uint16_t remaining_buf = (offset < cap) ? (uint16_t)(cap - offset) : 0;
   if (remaining_buf == 0) {
     msg->tp_state = ISOTP_FINISHED;
     return 0;

--- a/iso-tp.h
+++ b/iso-tp.h
@@ -38,7 +38,7 @@ typedef enum {
 #define TIMEOUT_CF       250 /* Timeout between CFs                          */
 #define MAX_FCWAIT_FRAME  10
 
-#define MAX_MSGBUF 4095   /* Received Message Buffer (ISO-TP max FF_DL is 4095) */
+#define MAX_MSGBUF 128    /* Default receive buffer size; fallback for buffer_size */
 struct Message_t
 {
   uint16_t len=0;
@@ -50,6 +50,7 @@ struct Message_t
   INT32U tx_id=0;
   INT32U rx_id=0;
   uint8_t *Buffer;
+  uint16_t buffer_size=0; /* Capacity of Buffer in bytes; 0 = MAX_MSGBUF */
 };
 
 class IsoTp
@@ -70,7 +71,7 @@ class IsoTp
     INT32U   wait_fc=0;
     INT32U   wait_cf=0;
     INT32U   wait_session=0;
-    uint16_t _max_message_size;
+    uint16_t buffer_capacity(struct Message_t* msg);
     uint8_t  can_send(INT32U id, uint8_t len, uint8_t *data);
     uint8_t  can_receive(void);
     uint8_t  send_fc(struct Message_t* msg);


### PR DESCRIPTION
## Summary

Commit bca0ceb does not close the overflow for the usual case. It keeps every write within `_max_message_size`, which the constructor fixes to `MAX_MSGBUF`, and the same commit raises `MAX_MSGBUF` to 4095. The library still has no way to learn how large the caller's buffer actually is. A caller whose `Message_t.Buffer` holds fewer than 4095 bytes, such as the 128-byte buffer the header documents, is still overwritten once a First Frame announces a large length and Consecutive Frames follow. Allocating 4095 bytes is also out of reach on the small AVR boards this library runs on.

This change keeps the receive path inside the buffer the caller actually provides, and closes three more out-of-bounds spots the earlier patch left open.

## Changes

A new `buffer_size` field in `Message_t` lets the caller state how many bytes `Buffer` holds, and every write during receive stays inside it. Left at 0 it falls back to `MAX_MSGBUF`, so existing callers that size their buffer to that constant stay safe.

`rcv_ff` now clamps the announced length to the buffer and rejects a malformed First Frame that announces fewer than 8 bytes, which used to underflow the `rest` counter. The first copy is limited to what fits.

`rcv_cf` keeps each copy within the space left in the buffer. The offset is widened so it cannot wrap around on long transfers.

`rcv_sf` clamps the single-frame length to 7, to the received frame length, and to the buffer. This removes an out-of-bounds read of the 8-byte CAN frame and a write past the buffer when the length nibble is 8 to 15.

`MAX_MSGBUF` goes back to 128 as a default and fallback, and the example sets `buffer_size`.

## Tests

A host test builds with AddressSanitizer and UndefinedBehaviorSanitizer using exact-size heap buffers, so any stray byte is caught. It covers the reported overflow, a tiny buffer, a crafted single-frame length of 15, a short First Frame, and a normal multi-frame message that has to arrive intact.

On bca0ceb the existing proof-of-concept reports a buffer overflow inside `IsoTp::receive`, a 7-byte write past a 128-byte buffer. With this branch the same frames produce no overflow.

Generated with claude code
